### PR TITLE
fix tabstops for 5x2table

### DIFF
--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -137,9 +137,9 @@
       "| ${1:Column1}   | ${2:Column2}    |",
       "|--------------- | --------------- |",
       "| ${3:Item1.1}   | ${4:Item2.1}   |",
-      "| ${4:Item1.2}   | ${5:Item2.2}   |",
-      "| ${6:Item1.3}   | ${7:Item2.3}   |",
-      "| ${8:Item1.4}   | ${9:Item2.4}   |",
+      "| ${5:Item1.2}   | ${6:Item2.2}   |",
+      "| ${7:Item1.3}   | ${8:Item2.3}   |",
+      "| ${9:Item1.4}   | ${10:Item2.4}   |",
       "${0}"
     ],
     "description": "Insert table with 5 rows and 2 columns. First row is heading."


### PR DESCRIPTION
Hello,
I recently started to use these snippets alot and noticed an error in the 5x2table which is going to list Item2.1 twice (please see screenshot if unclear) which in turn fills both slots at the same time when I use the tab key to quickly fill the table - I think this change should fix it and I like to share it.

![5x2table](https://user-images.githubusercontent.com/82734474/118890264-adae0900-b8fe-11eb-8f5d-f75ced806354.png)
